### PR TITLE
JUMPIF and JUMPIFNOT can make Condition be nil, causing Unluau to error out completely

### DIFF
--- a/src/Unluau/Lifter/Lifter.cs
+++ b/src/Unluau/Lifter/Lifter.cs
@@ -704,8 +704,12 @@ namespace Unluau
             OpCode code = instruction.GetProperties().Code;
 
             if (code == OpCode.JUMPIF || code == OpCode.JUMPIFNOT)
-                return code == OpCode.JUMPIFNOT ? registers.GetExpression(instruction.A)
-                            : new UnaryExpression(registers.GetExpression(instruction.A), UnaryExpression.UnaryOperation.Not);
+            {
+                Expression expression = registers.GetExpression(instruction.A) ?? registers.GetExpression(instruction.C);
+
+                return code == OpCode.JUMPIFNOT ? expression
+                            : new UnaryExpression(expression, UnaryExpression.UnaryOperation.Not);
+            }
 
             auxUsed = true;
 


### PR DESCRIPTION
Input Example:
https://github.com/MaximumADHD/Roblox-Client-Tracker/blob/79d958e1c5e9acff1f1a053873852d7c3a682b16/BuiltInPlugins/AnimationClipEditor/Bin/main.luac

Currently, this Unluau is unable to generate Pseudocode from this input, because it errors out
![image](https://github.com/atrexus/unluau/assets/12023782/a96f31e7-30bb-4488-97ae-0372cc4d8910)


&nbsp;

I have no clue if that what I did is correct.


So here are the differences:
https://www.diffchecker.com/JJD5VjjH/




&nbsp;

This is how the differences look like with both of my _"patches"_ applied.

https://www.diffchecker.com/oEnOdmc1/