### PR TITLE
Version5 bytecode support

### DIFF
--- a/src/Unluau/Deserializer/Deserializer.cs
+++ b/src/Unluau/Deserializer/Deserializer.cs
@@ -17,7 +17,7 @@ namespace Unluau
         private byte version, typesVersion;
         private OpCodeEncoding encoding;
 
-        private const byte MinVesion = 3, MaxVersion = 4;
+        private const byte MinVesion = 3, MaxVersion = 5;
         private const byte TypeVersion = 1;
 
         public Deserializer(Stream stream, OpCodeEncoding encoding)
@@ -227,6 +227,8 @@ namespace Unluau
                     return new TableConstant(keys);
                 case ConstantType.Closure:
                     return new ClosureConstant(reader.ReadInt32Compressed());
+                case ConstantType.Vector:
+                    return new VectorConstant(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
             }
 
             // Should never happen

--- a/src/Unluau/Deserializer/Models/Constant.cs
+++ b/src/Unluau/Deserializer/Models/Constant.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 
 namespace Unluau
@@ -16,7 +17,8 @@ namespace Unluau
 		String,
 		Import,
 		Table,
-		Closure
+		Closure,
+        Vector
 	}
 
 	public abstract class Constant
@@ -118,5 +120,12 @@ namespace Unluau
 		public ClosureConstant(int index)
 			: base(ConstantType.Closure, index)
 		{ }
-	}
+    }
+
+    public class VectorConstant : Constant<Vector4>
+    {
+        public VectorConstant(float x, float y, float z, float w)
+            : base(ConstantType.Vector, new(x, y, z, w))
+        { }
+    }
 }

--- a/src/Unluau/Deserializer/Models/OpProperties.cs
+++ b/src/Unluau/Deserializer/Models/OpProperties.cs
@@ -318,9 +318,12 @@ namespace Unluau
         // B: source register (for VAL/REF) or upvalue index (for UPVAL/UPREF)
         CAPTURE,
 
-        // removed in v3
-        DEP_JUMPIFEQK,
-        DEP_JUMPIFNOTEQK,
+        // SUBRK, DIVRK: compute arithmetic operation between the constant and a source register and put the result into target register
+        // A: target register
+        // B: source register
+        // C: constant table index (0..255); must refer to a number
+        SUBRK,
+        DIVRK,
 
         // FASTCALL1: perform a fast call of a built-in function using 1 register argument
         // A: builtin function id (see LuauBuiltinFunction)
@@ -470,8 +473,8 @@ namespace Unluau
             { OpCode.FASTCALL, new OpProperties(OpCode.FASTCALL, OpMode.iABC) },
             { OpCode.COVERAGE, new OpProperties(OpCode.COVERAGE, OpMode.iE) },
             { OpCode.CAPTURE, new OpProperties(OpCode.CAPTURE, OpMode.iABC) },
-            { OpCode.DEP_JUMPIFEQK, new OpProperties(OpCode.DEP_JUMPIFEQK, OpMode.iAD, true) },
-            { OpCode.DEP_JUMPIFNOTEQK, new OpProperties(OpCode.DEP_JUMPIFNOTEQK, OpMode.iAD, true) },
+            { OpCode.SUBRK, new OpProperties(OpCode.SUBRK, OpMode.iABC, false) },
+            { OpCode.DIVRK, new OpProperties(OpCode.DIVRK, OpMode.iABC, false) },
             { OpCode.FASTCALL1, new OpProperties(OpCode.FASTCALL1, OpMode.iABC) },
             { OpCode.FASTCALL2, new OpProperties(OpCode.FASTCALL2, OpMode.iABC, true) },
             { OpCode.FASTCALL2K, new OpProperties(OpCode.FASTCALL2K, OpMode.iABC, true) },

--- a/src/Unluau/Deserializer/Reader/BytecodeReader.cs
+++ b/src/Unluau/Deserializer/Reader/BytecodeReader.cs
@@ -70,6 +70,14 @@ namespace Unluau
         }
 
         /// <summary>
+        /// Reads a float.
+        /// </summary>
+        public float ReadSingle() 
+        { 
+            return Reader.ReadSingle();
+        }
+
+        /// <summary>
         /// Reads a 3 byte unsigned integer.
         /// </summary>
         public uint ReadUInt32()

--- a/src/Unluau/Lifter/Expressions/VectorLiteral.cs
+++ b/src/Unluau/Lifter/Expressions/VectorLiteral.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Valence. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Unluau
+{
+    public class VectorLiteral : Expression
+    {
+        public Vector4 Vec { get; set; }
+
+        public VectorLiteral(Vector4 vec)
+        {
+            Vec = vec;
+        }
+
+        public override void Write(Output output)
+        {
+            // Vector3 seems to be the only builtin type used for vector constant, yet vector constant holds 4 floats.
+            output.Write($"Vector3.new({Vec.X}, {Vec.Y}, {Vec.Z})");
+        }
+    }
+}

--- a/src/Unluau/Lifter/Lifter.cs
+++ b/src/Unluau/Lifter/Lifter.cs
@@ -807,6 +807,13 @@ namespace Unluau
                 return new Global(names);
             }
 
+            if (constant is VectorConstant)
+            {
+                VectorConstant vector = (VectorConstant)constant;
+
+                return new VectorLiteral(vector.Value);
+            }
+
             throw new DecompilerException(Stage.Lifter, "unexpected constant passed to 'ConstantToExpression'");
         }
 


### PR DESCRIPTION
Implements the changes required to support version 5 (What's currently used on the client).

If my assumption is wrong about Vector3 being the only builtin type utilizing the vector constant optimization, someone inform me and ill fix it.

Below is a test dumped directly from a game.
"print(Vector3.new(1.0, 1.0, 1.0), Color3.new(0, 0, 0))"

[vector_bytecode.txt](https://github.com/atrexus/unluau/files/14859936/vector_bytecode.txt)

Unluau.CLI.exe vector_bytecode.txt --encoding=1