### PR TITLE
Don't do +1 for FASTCALL2K?

### DIFF
--- a/src/Unluau/Chunk/Luau/Function.cs
+++ b/src/Unluau/Chunk/Luau/Function.cs
@@ -468,10 +468,15 @@ namespace Unluau.Chunk.Luau
                             // without processing the following instructions. The auxiliary instruction contains the constant index.
                             arguments.Add(new Reference(context, stack.Get(instruction.B)!));
                             arguments.Add(ConstantToBasicValue(context, Constants[Instructions[++pc].Value]));
+
+
+                            // FASTCALL2K's C, is ment to jump to CALL, but it skipped it due to +1
+                            // ++pc was used before, so it's not needed anymore?
+                            instruction = Instructions[pc += instruction.C];
                         }
 
                         // The C operand of the FASTCALL instruction is the jump index for the CALL instruction.
-                        if (instruction.Code != OpCode.CALL)
+                        if (instruction.Code != OpCode.CALL && instruction.Code != OpCode.FASTCALL2K)
                             instruction = Instructions[pc += instruction.C + 1];
 
                         if (instruction.Code != OpCode.FASTCALL2K)


### PR DESCRIPTION
FASTCALL2K is supposed to jump to CALL

but it skipped the CALL when I tested it with this https://github.com/MaximumADHD/Roblox-Client-Tracker/blob/roblox/BuiltInPlugins/AnimationClipEditor/Src/Components/AnimationClipEditorPlugin.luac


So I changed it and it gave me an output. See more info in DMs. Not sure if this is correct, but maybe it is.

CALL doesn't have AUX but has a ``instruction.C + 1`` because that's how it is in the docs. But FASTCALL2K doesn't have this description.